### PR TITLE
do not take higher avro version during test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,12 @@ dependencies {
     testImplementation "org.testng:testng:${testNGVersion}"
     testImplementation "com.facebook.airlift:testing:${airliftVersion}"
 
-    testCompile "io.pravega:schemaregistry-server:${pravegaSchemaRegistryVersion}"
+    testImplementation "io.pravega:schemaregistry-server:${pravegaSchemaRegistryVersion}"
+    testImplementation("org.apache.avro:avro") {
+        version {
+            strictly '1.8.1'
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
Closes #49 

Signed-off-by: Andrew Robertson <andrew.robertson@dell.com>

```
$ ./gradlew test -Pintegration

> Configure project :
configuration ':compile'

> Task :test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/home/andrew/.m2/repository/com/google/inject/guice/4.2.2/guice-4.2.2.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 53s
5 actionable tasks: 1 executed, 4 up-to-date
```