### PR TITLE
Issue 69: let server load by skipping call to metadata search keys

### DIFF
--- a/src/main/java/com/facebook/presto/s3/S3AccessObject.java
+++ b/src/main/java/com/facebook/presto/s3/S3AccessObject.java
@@ -167,12 +167,14 @@ public class S3AccessObject
         throw new UnsupportedOperationException("not yet implemented");
     }
 
-    public JSONObject getMetaData(String bucketName){
+    public JSONObject loadColumnsFromMetaDataSearchKeys(String bucketName){
         JSONObject schema =  new JSONObject();
         JSONArray columns = new JSONArray();
         MetadataSearchList listOfMetaData;
         try {
-            listOfMetaData  = s3Client.listBucketMetadataSearchKeys(bucketName);
+            // effectively disables loading due to issue https://github.com/EMCECS/presto-s3-connector/issues/69
+            // revisit when metadata search fully implemented with https://github.com/EMCECS/presto-s3-connector/issues/57
+            listOfMetaData  = new MetadataSearchList();
             for(MetadataSearchKey entry: listOfMetaData.getIndexableKeys()){
                 if(entry.getDatatype() == MetadataSearchDatatype.string){
                     columns.put(new JSONObject().put("name", entry.getName()).put("type", "VARCHAR"));

--- a/src/main/java/com/facebook/presto/s3/S3TableDescriptionSupplier.java
+++ b/src/main/java/com/facebook/presto/s3/S3TableDescriptionSupplier.java
@@ -64,7 +64,7 @@ public class S3TableDescriptionSupplier implements Supplier<Map<SchemaTableName,
         for(Bucket bucket: listOfBuckets){
             JSONObject sources = new JSONObject();
             S3Table table = this.objectDescriptionCodec.fromJson(
-                    this.accessObject.getMetaData(bucket.getName()).
+                    this.accessObject.loadColumnsFromMetaDataSearchKeys(bucket.getName()).
                             put("sources", sources).
                             put("objectDataFormat", DEFAULT_OBJECT_FILE_TYPE).
                             put("hasHeaderRow", DEFAULT_HAS_HEADER_ROW).


### PR DESCRIPTION
Closes #69 

Signed-off-by: Andrew Robertson <andrew.robertson@dell.com>

to test, set config to OBS, started server.  also get md search message when trying to use (good)

```
presto:s3_buckets> select * from testbucket;
Query 20211102_185038_00004_ptvan failed: MetaData Search is not Enabled for this Bucket
```

passes integration tests
```
<===========--> 90% EXECUTING [1m 54s]
> :test > 105 tests completed
BUILD SUCCESSFUL in 1m 55s
6 actionable tasks: 4 executed, 2 up-to-date
```