### PR TITLE
Change csvWriter to quote columns with field separators

### DIFF
--- a/src/main/java/com/facebook/presto/s3/S3PageSink.java
+++ b/src/main/java/com/facebook/presto/s3/S3PageSink.java
@@ -205,7 +205,7 @@ public class S3PageSink
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         OutputStreamWriter osw = new OutputStreamWriter(baos);
         CSVWriter csvWriter = new CSVWriter(osw, field_delimiter.charAt(0),
-                ICSVWriter.NO_QUOTE_CHARACTER,
+                ICSVWriter.DEFAULT_QUOTE_CHARACTER,
                 ICSVWriter.NO_ESCAPE_CHARACTER, record_delimiter);
 
         List<String[]> inputPage = new ArrayList<String[]>();
@@ -238,7 +238,7 @@ public class S3PageSink
             row = ls.toArray(row);
             inputPage.add(row);
         }
-        csvWriter.writeAll(inputPage);
+        csvWriter.writeAll(inputPage, false);
         try {
             csvWriter.flush();
         } catch (Exception e) {

--- a/src/test/java/com/facebook/presto/s3/integration/S3QueryTest.java
+++ b/src/test/java/com/facebook/presto/s3/integration/S3QueryTest.java
@@ -343,8 +343,19 @@ public class S3QueryTest
     @Test (dependsOnMethods = "testCreateTable")
     public void testInsertRow() {
         log.info("Test: testInsertRow");
-        queryRunner.execute("INSERT INTO s3.newschema.csvtable VALUES (100, 'GEORGE', 20.0)");
-        assertEquals(queryRunner.execute("SELECT * FROM s3.newschema.csvtable").getMaterializedRows().size(), 1);
+        queryRunner.execute("INSERT INTO s3.newschema.csvtable VALUES (100, 'JOHN, PAUL, GEORGE, RINGO and \"YOKO\"', 20.0)");
+        List<MaterializedRow> rows = queryRunner.execute("SELECT * FROM s3.newschema.csvtable").getMaterializedRows();
+        int numRows = 0;
+        boolean foundBeatles = false;
+        for (MaterializedRow row : rows) {
+            log.debug("Test: testInsertRow.  Found row: " + row.toString());
+            if (row.toString().contains("JOHN, PAUL, GEORGE, RINGO and \"YOKO\"")) {
+                foundBeatles = true;
+            }
+            numRows++;
+        }
+        assertTrue(foundBeatles);
+        assertTrue(numRows == 1);
     }
 
     @Test (dependsOnMethods = "testInsertRow")


### PR DESCRIPTION
Signed-off-by: Chip Maurer <chip.maurer@dell.com>

If a VARCHAR column that is being inserted into via CsvWriter contained the field separator, the cell should have been quoted, but it was not.  This fix changes the CsvWriter constructor to define a default quote character.